### PR TITLE
Test uses prefix of the current user ID and cleanup for failed tests

### DIFF
--- a/test/ksds.js
+++ b/test/ksds.js
@@ -35,36 +35,49 @@ function readUntilEnd(file, done) {
   );
 }
 
+const prefix=require("os").userInfo().username;
+const testDsn=prefix + ".TEST.VSAM.KSDS2";
+const schema=JSON.parse(fs.readFileSync('test/test.json'));
+
 describe("Key Sequenced Dataset", function() {
+  before(function() {
+    // Cleanup after failed tests
+    if (vsam.exist(testDsn)) {
+      var file = vsam.openSync(testDsn,
+          JSON.parse(fs.readFileSync('test/test.json')));
+      expect(file.close()).to.not.throw;
+      file.dealloc((err) => {
+        assert.ifError(err);
+      });
+    }
+  });
+
   it("ensure test dataset does not exist", function(done) {
-    expect(vsam.exist("BARBOZA.TEST.VSAM.KSDS2")).to.be.false;
+    expect(vsam.exist(testDsn)).to.be.false;
     done();
   });
 
   it("create an empty dataset", function(done) {
-    var file = vsam.allocSync("BARBOZA.TEST.VSAM.KSDS2",
-                             JSON.parse(fs.readFileSync('test/test.json')))
+    var file = vsam.allocSync(testDsn, schema);
     expect(file).not.be.null;
     expect(file.close()).to.not.throw;
     done();
   });
 
   it("ensure test dataset exists", function(done) {
-    expect(vsam.exist("BARBOZA.TEST.VSAM.KSDS2")).to.be.true;
+    expect(vsam.exist(testDsn)).to.be.true;
     done();
   });
 
   it("open and close the existing dataset", function(done) {
-    var file = vsam.openSync("BARBOZA.TEST.VSAM.KSDS2",
-                             JSON.parse(fs.readFileSync('test/test.json')))
+    var file = vsam.openSync(testDsn, schema);
     expect(file).to.not.be.null;
     expect(file.close()).to.not.throw;
     done();
   });
 
  it("write new record", function(done) {
-    var file = vsam.openSync("BARBOZA.TEST.VSAM.KSDS2",
-                             JSON.parse(fs.readFileSync('test/test.json')))
+    var file = vsam.openSync(testDsn, schema);
     record = {
       key: "00126",
       name: "JOHN",
@@ -78,8 +91,7 @@ describe("Key Sequenced Dataset", function() {
   });
 
   it("read a record and verify properties", function(done) {
-    var file = vsam.openSync("BARBOZA.TEST.VSAM.KSDS2",
-                             JSON.parse(fs.readFileSync('test/test.json')))
+    var file = vsam.openSync(testDsn, schema);
     file.read( (record, err) => {
       assert.ifError(err);
       expect(record).to.not.be.null;
@@ -92,8 +104,7 @@ describe("Key Sequenced Dataset", function() {
   });
 
   it("find existing record and verify data", function(done) {
-    var file = vsam.openSync("BARBOZA.TEST.VSAM.KSDS2",
-                             JSON.parse(fs.readFileSync('test/test.json')))
+    var file = vsam.openSync(testDsn, schema);
     file.find("00126", (record, err) => {
       assert.ifError(err);
       assert.equal(record.key, "00126", "record has been created");
@@ -105,8 +116,7 @@ describe("Key Sequenced Dataset", function() {
   });
 
   it("write new record after read", function(done) {
-    var file = vsam.openSync("BARBOZA.TEST.VSAM.KSDS2",
-                             JSON.parse(fs.readFileSync('test/test.json')))
+    var file = vsam.openSync(testDsn, schema);
     file.read((record, err) => {
       record.key = "00125";
       record.name = "JANE";
@@ -126,8 +136,7 @@ describe("Key Sequenced Dataset", function() {
   });
 
   it("delete existing record", function(done) {
-    var file = vsam.openSync("BARBOZA.TEST.VSAM.KSDS2",
-                             JSON.parse(fs.readFileSync('test/test.json')))
+    var file = vsam.openSync(testDsn, schema);
     file.find("00126", (record, err) => {
       file.delete( (err) => {
         assert.ifError(err);
@@ -141,14 +150,13 @@ describe("Key Sequenced Dataset", function() {
   });
 
   it("reads all records until the end", function(done) {
-    var file = vsam.openSync("BARBOZA.TEST.VSAM.KSDS2",
-                             JSON.parse(fs.readFileSync('test/test.json')))
+    var file = vsam.openSync(testDsn, schema);
     readUntilEnd(file, done);
   });
 
   it("open a vsam file with incorrect key length", function(done) {
     expect(() => {
-      vsam.openSync("BARBOZA.TEST.VSAM.KSDS2",
+      vsam.openSync(testDsn,
                     JSON.parse(fs.readFileSync('test/test-error.json')))
     }).to.throw(/Incorrect key length/);
     done();
@@ -156,15 +164,13 @@ describe("Key Sequenced Dataset", function() {
 
   it("return error for non-existent dataset", function(done) {
     expect(() => {
-      vsam.openSync("A..B",
-                    JSON.parse(fs.readFileSync('test/test.json')))
+      vsam.openSync("A..B", schema);
     }).to.throw(/Invalid dataset name/);
     done();
   });
 
   it("update existing record and delete it", function(done) {
-    var file = vsam.openSync("BARBOZA.TEST.VSAM.KSDS2",
-                             JSON.parse(fs.readFileSync('test/test.json')))
+    var file = vsam.openSync(testDsn, schema);
     file.find("00125", (record, err) => {
       assert.ifError(err);
       record.name = "KEVIN";
@@ -186,8 +192,7 @@ describe("Key Sequenced Dataset", function() {
   });
 
   it("deallocate a dataset", function(done) {
-    var file = vsam.openSync("BARBOZA.TEST.VSAM.KSDS2",
-                             JSON.parse(fs.readFileSync('test/test.json')))
+    var file = vsam.openSync(testDsn, schema);
     expect(file.close()).to.not.throw;
     file.dealloc((err) => {
       assert.ifError(err);


### PR DESCRIPTION
This PR does two things:
- Uses the user ID of the current user as the prefix for the test VSAM data set
- The test deletes the test VSAM data set if it was not deleted by the previous test run