### PR TITLE
convert vsam.js npm to use N-API, resolve memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a [Node.js](https://nodejs.org/en/) module available through the
 -->
 
 Before installing, [download and install Node.js](https://developer.ibm.com/node/sdk/ztp/).
-Node.js 6.11.4 or higher is required.
+Node.js 8.16.2 or higher is required.
 
 ## Simple to use
 

--- a/VsamFile.cpp
+++ b/VsamFile.cpp
@@ -10,40 +10,17 @@
 #include <sstream>
 #include <numeric>
 
-using v8::Context;
-using v8::Function;
-using v8::FunctionCallbackInfo;
-using v8::FunctionTemplate;
-using v8::Isolate;
-using v8::Local;
-using v8::Number;
-using v8::Object;
-using v8::Persistent;
-using v8::String;
-using v8::Value;
-using v8::Exception;
-using v8::HandleScope;
-using v8::Handle;
-using v8::Array;
-using v8::Integer;
-using v8::Boolean;
-using v8::MaybeLocal;
-
-Persistent<Function> VsamFile::OpenSyncConstructor;
-Persistent<Function> VsamFile::AllocSyncConstructor;
+Napi::FunctionReference VsamFile::constructor_;
 
 static const char* hexstrToBuffer (char* hexbuf, int buflen, const char* hexstr);
 static const char* bufferToHexstr (char* hexstr, const char* hexbuf, const int hexbuflen);
 
 static void print_amrc() {
-  __amrc_type currErr = *__amrc; /* copy contents of __amrc */
-  /* structure so that values */
-#pragma convert("IBM-1047")
+  __amrc_type currErr = *__amrc;
   printf("R15 value = %d\n", currErr.__code.__feedback.__rc);
   printf("Reason code = %d\n", currErr.__code.__feedback.__fdbk);
   printf("RBA = %d\n", currErr.__RBA);
   printf("Last op = %d\n", currErr.__last_op);
-#pragma convert(pop)
 }
 
 
@@ -55,20 +32,14 @@ void VsamFile::DeleteCallback(uv_work_t* req, int status) {
   if (status == UV_ECANCELED)
     return;
 
-  const unsigned argc = 1;
-  HandleScope scope(obj->isolate_);
-  Local<Value> argv[argc];
+  Napi::HandleScope scope(obj->env_);
   if (obj->lastrc_ != 0) {
-    argv[0] = Exception::TypeError(
-                String::NewFromUtf8(obj->isolate_, "Failed to delete"));
+    obj->cb_.Call(obj->env_.Global(), {Napi::String::New(obj->env_, "Failed to delete")});
     obj->lastrc_ = 0;
   }
   else
-    argv[0] = v8::Null(obj->isolate_);
-  auto fn = Local<Function>::New(obj->isolate_, obj->cb_);
-  fn->Call(Null(obj->isolate_), argc, argv);
+    obj->cb_.Call(obj->env_.Global(), {obj->env_.Null()});
 }
-
 
 void VsamFile::WriteCallback(uv_work_t* req, int status) {
   VsamFile* obj = (VsamFile*)(req->data);
@@ -77,16 +48,13 @@ void VsamFile::WriteCallback(uv_work_t* req, int status) {
   if (status == UV_ECANCELED)
     return;
 
-  const unsigned argc = 1;
-  HandleScope scope(obj->isolate_);
-  Local<Value> argv[argc];
-  if (obj->lastrc_ != obj->reclen_)
-    argv[0] = Exception::TypeError(
-                String::NewFromUtf8(obj->isolate_, "Failed to write"));
-  else
-    argv[0] = v8::Null(obj->isolate_);
-  auto fn = Local<Function>::New(obj->isolate_, obj->cb_);
-  fn->Call(Null(obj->isolate_), argc, argv);
+  Napi::HandleScope scope(obj->env_);
+  if (obj->lastrc_ != obj->reclen_) {
+    obj->cb_.Call(obj->env_.Global(), {Napi::String::New(obj->env_,"Failed to write")});
+  }
+  else {
+    obj->cb_.Call(obj->env_.Global(), {obj->env_.Null()});
+  }
 }
 
 
@@ -98,11 +66,8 @@ void VsamFile::UpdateCallback(uv_work_t* req, int status) {
   if (status == UV_ECANCELED)
     return;
 
-  const unsigned argc = 1;
-  HandleScope scope(obj->isolate_);
-  Local<Value> argv[argc] = { v8::Null(obj->isolate_) };
-  auto fn = Local<Function>::New(obj->isolate_, obj->cb_);
-  fn->Call(Null(obj->isolate_), argc, argv);
+  Napi::HandleScope scope(obj->env_);
+  obj->cb_.Call(obj->env_.Global(), {obj->env_.Null()});
 }
 
 
@@ -116,41 +81,26 @@ void VsamFile::ReadCallback(uv_work_t* req, int status) {
   char* buf = (char*)(obj->buf_);
 
   if (buf != NULL) {
-    const unsigned argc = 2;
-    HandleScope scope(obj->isolate_);
-    Local<Object> record = Object::New(obj->isolate_);
+    Napi::HandleScope scope(obj->env_);
+    Napi::Object record = Napi::Object::New(obj->env_);
     for(auto i = obj->layout_.begin(); i != obj->layout_.end(); ++i) {
       if (i->type == LayoutItem::STRING) { 
-        std::string str; 
-        transform(buf, buf + i->maxLength, back_inserter(str), [](char c) -> char {
-          __e2a_l(&c, 1);
-          return c;
-        });
-        record->Set(String::NewFromUtf8(obj->isolate_, &(i->name[0])),
-                //node::Buffer::Copy(obj->isolate_, key.data(), key.size()).ToLocalChecked());
-                String::NewFromUtf8(obj->isolate_, str.c_str()));
+        std::string str(buf,i->maxLength);
+        record.Set(&(i->name[0]), str.c_str());
       }
       else if (i->type == LayoutItem::HEXADECIMAL) { 
         char hexstr[(i->maxLength*2)+1];
         bufferToHexstr(hexstr, buf, i->maxLength);
         std::string str(hexstr); 
-        record->Set(String::NewFromUtf8(obj->isolate_, &(i->name[0])),
-                String::NewFromUtf8(obj->isolate_, str.c_str()));
+        record.Set(&(i->name[0]), str.c_str());
       }
       buf += i->maxLength;
     }
-    Local<Value> argv[argc] = { record, v8::Null(obj->isolate_) };
-
-    auto fn = Local<Function>::New(obj->isolate_, obj->cb_);
-    fn->Call(Null(obj->isolate_), argc, argv);
+    obj->cb_.Call(obj->env_.Global(), {record, obj->env_.Null()});
   }
   else {
-    const unsigned argc = 2;
-    HandleScope scope(obj->isolate_);
-    Local<Value> argv[argc] = { v8::Null(obj->isolate_),
-                                v8::Null(obj->isolate_) };
-    auto fn = Local<Function>::New(obj->isolate_, obj->cb_);
-    fn->Call(Null(obj->isolate_), argc, argv);
+    Napi::HandleScope scope(obj->env_);
+    obj->cb_.Call(obj->env_.Global(), { obj->env_.Null(), obj->env_.Null()});
   }
 }
 
@@ -162,8 +112,8 @@ void VsamFile::Find(uv_work_t* req) {
   int buflen;
   if (obj->keybuf_) {
     if (obj->keybuf_len_==0) {
-      Exception::TypeError(String::NewFromUtf8(obj->isolate_,
-                           "find: Buffer object is empty."));
+      Napi::TypeError::New(obj->env_, "find: Buffer object is empty.").ThrowAsJavaScriptException();
+      return;
     }
     buf = obj->keybuf_;
     buflen = obj->keybuf_len_;
@@ -187,6 +137,9 @@ chk:
     int ret = fread(buf, obj->reclen_, 1, obj->stream_);
     //TODO: if read fails
     if (ret == 1) {
+      if (obj->buf_) {
+        free(obj->buf_);
+      }
       obj->buf_ = malloc(obj->reclen_);
       //TODO: if malloc fails
       memcpy(obj->buf_, buf, obj->reclen_);
@@ -234,8 +187,10 @@ void VsamFile::Delete(uv_work_t* req) {
 void VsamFile::Write(uv_work_t* req) {
   VsamFile* obj = (VsamFile*)(req->data);
   obj->lastrc_ = fwrite(obj->buf_, 1, obj->reclen_, obj->stream_);
-  free(obj->buf_);
-  obj->buf_ = NULL;
+  if (obj->buf_) {
+    free(obj->buf_);
+    obj->buf_ = NULL;
+  }
   if (obj->keybuf_) {
     free(obj->keybuf_);
     obj->keybuf_ = NULL;
@@ -261,10 +216,8 @@ void VsamFile::Update(uv_work_t* req) {
 void VsamFile::Dealloc(uv_work_t* req) {
   VsamFile* obj = (VsamFile*)(req->data);
 
-#pragma convert("IBM-1047")
   std::ostringstream dataset;
   dataset << "//'" << obj->path_.c_str() << "'";
-#pragma convert(pop)
 
   obj->lastrc_ = remove(dataset.str().c_str());
 }
@@ -274,78 +227,74 @@ void VsamFile::DeallocCallback(uv_work_t* req, int status) {
   VsamFile* obj = (VsamFile*)(req->data);
   delete req;
 
-  HandleScope scope(obj->isolate_);
+  Napi::HandleScope scope(obj->env_);
   if (status == UV_ECANCELED) {
     return;
   }
   else if (obj->lastrc_ != 0) {
-    const unsigned argc = 1;
-    Local<Value> argv[argc] = {
-      Exception::TypeError(String::NewFromUtf8(obj->isolate_,
-                           "Couldn't deallocate dataset"))
-    };
-
-    auto fn = Local<Function>::New(obj->isolate_, obj->cb_);
-    fn->Call(Null(obj->isolate_), argc, argv);
+    obj->cb_.Call(obj->env_.Global(), {Napi::String::New(obj->env_, "Couldn't deallocate dataset")});
   }
   else {
-    const unsigned argc = 1;
-    Local<Value> argv[argc] = {
-      Null(obj->isolate_)
-    };
-
-    auto fn = Local<Function>::New(obj->isolate_, obj->cb_);
-    fn->Call(Null(obj->isolate_), argc, argv);
+    obj->cb_.Call(obj->env_.Global(), {obj->env_.Null()});
   }
 }
 
 
-VsamFile::VsamFile(std::string& path, std::vector<LayoutItem>& layout,
-                   Isolate* isolate, bool alloc, int key_i ) :
-    path_(path),
+VsamFile::VsamFile(const Napi::CallbackInfo& info)
+: Napi::ObjectWrap<VsamFile>(info),
+    env_(info.Env()),
     stream_(NULL),
     keylen_(-1),
     lastrc_(0),
-    layout_(layout),
-    key_i_(key_i),
-    isolate_(isolate),
     buf_(NULL),
     keybuf_(NULL),
     keybuf_len_(0) {
+  Napi::HandleScope scope(env_);
 
-#pragma convert("IBM-1047")
-    std::ostringstream dataset;
-    dataset << "//'" << path.c_str() << "'";
-    stream_ = fopen(dataset.str().c_str(), "rb+,type=record");
-    int err = __errno2();
-#pragma convert(pop)
+  if (info.Length() != 4) {
+    Napi::Error::New(env_, "Wrong number of arguments to VsamFile::VsamFile")
+        .ThrowAsJavaScriptException();
+    return;
+  }
+
+  if (!info[0].IsString() || !info[1].IsBuffer() || !info[2].IsBoolean() || !info[
+3].IsNumber()) {
+    Napi::Error::New(env_, "Wrong arguments to VsamFile::VsamFile")
+        .ThrowAsJavaScriptException();
+    return;
+  }
+
+  path_ = static_cast<std::string>(info[0].As<Napi::String>());
+  Napi::Buffer<std::vector<LayoutItem>> b = info[1].As<Napi::Buffer<std::vector<LayoutItem>>>();
+  layout_ = *(static_cast<std::vector<LayoutItem>*>(b.Data()));
+  bool alloc(static_cast<bool>(info[2].As<Napi::Boolean>()));
+  key_i_ = static_cast<int>(info[3].As<Napi::Number>().Int32Value());
+
+  std::ostringstream dataset;
+  dataset << "//'" << path_.c_str() << "'";
+  stream_ = fopen(dataset.str().c_str(), "rb+,type=record");
+  int err = __errno2();
 
   if (!alloc) {
-
     if (stream_ == NULL) {
       errmsg_ = err == 0xC00B0641 ? "Dataset does not exist" : "Invalid dataset name";
       lastrc_ = -1;
       return;
     }
-
-#pragma convert("IBM-1047")
     stream_ = freopen(dataset.str().c_str(), "ab+,type=record", stream_);
-#pragma convert(pop)
     if (stream_ == NULL) {
       errmsg_ = "Failed to open dataset";
       lastrc_ = -1;
       return;
     }
-
   } else {
-    
     if (stream_ != NULL) {
       errmsg_ = "Dataset already exists";
       fclose(stream_);
+      stream_ = NULL;
       lastrc_ = -1;
       return;
     }
-
     if (err != 0xC00B0641) {
       errmsg_ = "Invalid dataset format";
       lastrc_ = -1;
@@ -353,9 +302,7 @@ VsamFile::VsamFile(std::string& path, std::vector<LayoutItem>& layout,
     }
 
     std::ostringstream ddname;
-#pragma convert("IBM-1047")
     ddname << "NAMEDD";
-#pragma convert(pop)
 
     __dyn_t dyn;
     dyninit(&dyn);
@@ -372,9 +319,7 @@ VsamFile::VsamFile(std::string& path, std::vector<LayoutItem>& layout,
       return;
     }
 
-#pragma convert("IBM-1047")
     stream_ = fopen(dataset.str().c_str(), "ab+,type=record");
-#pragma convert(pop)
     if (stream_ == NULL) {
       errmsg_ = "Failed to open new dataset";
       lastrc_ = -1;
@@ -382,19 +327,18 @@ VsamFile::VsamFile(std::string& path, std::vector<LayoutItem>& layout,
     }
   }
 
-  fldata_t info;
-  fldata(stream_, NULL, &info);
-  keylen_ = info.__vsamkeylen;
-  reclen_ = info.__maxreclen;
+  fldata_t dinfo;
+  fldata(stream_, NULL, &dinfo);
+  keylen_ = dinfo.__vsamkeylen;
+  reclen_ = dinfo.__maxreclen;
   if (keylen_ != layout_[0].maxLength) {
     errmsg_ = "Incorrect key length";
     fclose(stream_);
+    stream_ = NULL;
     lastrc_ = -1;
     return;
   }
-
 }
-
 
 VsamFile::~VsamFile() {
   if (stream_ != NULL)
@@ -402,318 +346,247 @@ VsamFile::~VsamFile() {
 }
 
 
-void VsamFile::SetPrototypeMethods(Local<FunctionTemplate>& tpl) {
-  // Prototype
-  NODE_SET_PROTOTYPE_METHOD(tpl, "read", Read);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "find", FindEq);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "findeq", FindEq);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "findge", FindGe);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "findfirst", FindFirst);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "findlast", FindLast);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "update", Update);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "write", Write);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "delete", Delete);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "close", Close);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "dealloc", Dealloc);
-}
-
-
-void VsamFile::Init(Isolate* isolate) {
+void VsamFile::Init(Napi::Env env, Napi::Object exports) {
   // Prepare constructor template
-  Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, VsamFile::OpenSync);
-  tpl->SetClassName(String::NewFromUtf8(isolate, "VsamFile"));
-  tpl->InstanceTemplate()->SetInternalFieldCount(1);
-  SetPrototypeMethods(tpl);
-  OpenSyncConstructor.Reset(isolate, tpl->GetFunction());
+  Napi::HandleScope scope(env);
 
-  tpl = FunctionTemplate::New(isolate, VsamFile::AllocSync);
-  tpl->SetClassName(String::NewFromUtf8(isolate, "VsamFile"));
-  tpl->InstanceTemplate()->SetInternalFieldCount(1);
-  SetPrototypeMethods(tpl);
-  AllocSyncConstructor.Reset(isolate, tpl->GetFunction());
-}
-
-
-void VsamFile::Construct(const FunctionCallbackInfo<Value>& args, bool alloc) {
-  Isolate* isolate = args.GetIsolate();
-
-  // Check the number of arguments passed.
-  if (args.Length() != 2) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
-    return;
-  }
-
-  if (!args[0]->IsString()) {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong arguments")));
-    return;
-  }
-
-  std::string path (*v8::String::Utf8Value(args[0]->ToString()));
-  transform(path.begin(), path.end(), path.begin(), [](char c) -> char {
-    __a2e_l(&c, 1);
-    return c;
+  Napi::Function func = DefineClass(env, "VsamFile", {
+    InstanceMethod("read", &VsamFile::Read),
+    InstanceMethod("find", &VsamFile::FindEq),
+    InstanceMethod("findeq", &VsamFile::FindEq),
+    InstanceMethod("findge", &VsamFile::FindGe),
+    InstanceMethod("findfirst", &VsamFile::FindFirst),
+    InstanceMethod("findlast", &VsamFile::FindLast),
+    InstanceMethod("update", &VsamFile::Update),
+    InstanceMethod("write", &VsamFile::Write),
+    InstanceMethod("delete", &VsamFile::Delete),
+    InstanceMethod("close", &VsamFile::Close),
+    InstanceMethod("dealloc", &VsamFile::Dealloc)
   });
 
-  Local<Object> schema = args[1]->ToObject();
-  Local<Array> properties = schema->GetPropertyNames();
+  constructor_ = Napi::Persistent(func);
+  constructor_.SuppressDestruct();
+
+  exports.Set("VsamFile", func);
+}
+
+
+Napi::Value VsamFile::Construct(const Napi::CallbackInfo& info, bool alloc) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() != 2) {
+    Napi::Error::New(env, "Wrong number of arguments.").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  if (!info[0].IsString()) {
+    Napi::TypeError::New(env, "First argument must be a string.").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  std::string path (static_cast<std::string>(info[0].As<Napi::String>()));
+
+  Napi::Object schema = info[1].ToObject();
+  Napi::Array properties = schema.GetPropertyNames();
   std::vector<LayoutItem> layout;
   int key_i = 0; // for its data type - default to first field if no "key" found
-  for (int i = 0; i < properties->Length(); ++i) {
-    String::Utf8Value name(properties->Get(i)->ToString());
- 
-    Local<Object> item = Local<Object>::Cast(schema->Get(properties->Get(i)));
+  for (int i = 0; i < properties.Length(); ++i) {
+    std::string name (static_cast<std::string>(Napi::String (env, properties.Get(i).ToString())));
+
+    Napi::Object item = schema.Get(properties.Get(i)).As<Napi::Object>();
     if (item.IsEmpty()) {
-      isolate->ThrowException(Exception::TypeError( String::NewFromUtf8(isolate, "Json is incorrect")));
-      return;
+      Napi::Error::New(env, "JSON is incorrect.").ThrowAsJavaScriptException();
+      return env.Null();
     }
 
-    Local<Value> length = Local<Value>::Cast(item->Get( Local<String>(String::NewFromUtf8(isolate, "maxLength"))));
-    if (length.IsEmpty() || !length->IsNumber()) {
-      isolate->ThrowException(Exception::TypeError( String::NewFromUtf8(isolate, "Json is incorrect")));
-      return;
+    Napi::Value length = item.Get(Napi::String::New(env,"maxLength"));
+    if (length.IsEmpty() || !length.IsNumber()) {
+      Napi::Error::New(env, "JSON is incorrect.").ThrowAsJavaScriptException();
+      return env.Null();
     }
 
-    Local<Value> jtype = item->Get( Local<String>(String::NewFromUtf8(isolate, "type")));
+    Napi::Value jtype = item.Get(Napi::String::New(env,"type"));
     if (jtype.IsEmpty()) {
-      isolate->ThrowException(Exception::TypeError( String::NewFromUtf8(isolate, "Json \"type\" is empty")));
-      return;
+      Napi::Error::New(env, "JSON \"type\" is empty.").ThrowAsJavaScriptException();
+      return env.Null();
     }
-    std::string stype(*v8::String::Utf8Value(jtype));
+
+    std::string stype(static_cast<std::string>(jtype.As<Napi::String>()));
     if (!strcmp(stype.c_str(),"string")) {
-      layout.push_back(LayoutItem(name, length->ToInteger()->Value(), LayoutItem::STRING));
+      layout.push_back(LayoutItem(name, length.ToNumber().Int32Value(), LayoutItem::STRING));
     } else if (!strcmp(stype.c_str(),"hexadecimal")) {
-      layout.push_back(LayoutItem(name, length->ToInteger()->Value(), LayoutItem::HEXADECIMAL));
+      layout.push_back(LayoutItem(name, length.ToNumber().Int32Value(), LayoutItem::HEXADECIMAL));
     } else {
-      isolate->ThrowException(Exception::TypeError( String::NewFromUtf8(isolate, "Json \"type\" must be \"string\" or \"hexadecimal\"")));
-      return;
+      Napi::Error::New(env, "JSON \"type\" must be \"string\" or \"hexadecimal\"").ThrowAsJavaScriptException();
+      return env.Null();
     }
-    if (!strcmp(*name,"key")) {
+
+    if (!strcmp(name.c_str(),"key")) {
       key_i = i;
     }
   }
 
-  VsamFile *obj = new VsamFile(path, layout, isolate, alloc, key_i);
-  if (obj->lastrc_) {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, obj->errmsg_.c_str())));
-    delete obj;
-    return;
+  Napi::HandleScope scope(env);
+  Napi::Object obj = constructor_.New({
+    Napi::String::New(env, path),
+    Napi::Buffer<std::vector<LayoutItem>>::New(env, &layout, layout.size()),
+    Napi::Boolean::New(env, alloc),
+    Napi::Number::New(env, key_i)});
+  VsamFile* p = Napi::ObjectWrap<VsamFile>::Unwrap(obj);
+  if (p->lastrc_) {
+    Napi::Error::New(env, p->errmsg_.c_str()).ThrowAsJavaScriptException();
+    delete p;
+    return env.Null();
   }
-  obj->Wrap(args.This());
-  args.GetReturnValue().Set(args.This());
+
+  //return scope.Escape(napi_value(obj)).ToObject();
+  return obj;
 }
 
 
-void VsamFile::AllocSync(const FunctionCallbackInfo<Value>& args) {
-  if (args.IsConstructCall()) {
-    Construct(args, true);
-  } else {
-    // Invoked as plain function `MyObject(...)`, turn into construct call.
-    Isolate* isolate = args.GetIsolate();
-    const int argc = 2;
-    Local<Value> argv[argc] = { args[0], args[1] };
-    Local<Function> cons = Local<Function>::New(isolate, AllocSyncConstructor);
-    Local<Context> context = isolate->GetCurrentContext();
-    MaybeLocal<Object> instance =
-        cons->NewInstance(context, argc, argv);
-    if(!instance.IsEmpty())
-      args.GetReturnValue().Set(instance.ToLocalChecked());
-  }
+Napi::Value VsamFile::AllocSync(const Napi::CallbackInfo& info) {
+  return Construct(info, true);
 }
 
 
-void VsamFile::OpenSync(const FunctionCallbackInfo<Value>& args) {
-  if (args.IsConstructCall()) {
-    Construct(args, false);
-  } else {
-    // Invoked as plain function `MyObject(...)`, turn into construct call.
-    Isolate* isolate = args.GetIsolate();
-    const int argc = 2;
-    Local<Value> argv[argc] = { args[0], args[1] };
-    Local<Function> cons = Local<Function>::New(isolate, OpenSyncConstructor);
-    Local<Context> context = isolate->GetCurrentContext();
-    MaybeLocal<Object> instance =
-        cons->NewInstance(context, argc, argv);
-    if(!instance.IsEmpty())
-      args.GetReturnValue().Set(instance.ToLocalChecked());
-  }
+Napi::Value VsamFile::OpenSync(const Napi::CallbackInfo& info) {
+  Napi::Value obj = Construct(info, false);
+return obj;
 }
 
 
-void VsamFile::Exist(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  if (args.Length() != 1) {
+Napi::Boolean VsamFile::Exist(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() != 1) {
     // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
-    return;
+    Napi::Error::New(env, "Wrong number of arguments.").ThrowAsJavaScriptException();
+    return Napi::Boolean::New(env, false);
   }
 
-  if (!args[0]->IsString()) {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong arguments")));
-    return;
+  if (!info[0].IsString()) {
+    Napi::TypeError::New(env, "Wrong arguments").ThrowAsJavaScriptException();
+    return Napi::Boolean::New(env, false);
   }
 
-  std::string path (*v8::String::Utf8Value(args[0]->ToString()));
-  transform(path.begin(), path.end(), path.begin(), [](char c) -> char {
-    __a2e_l(&c, 1);
-    return c;
-  });
+  std::string path (static_cast<std::string>(info[0].As<Napi::String>()));
+  std::ostringstream dataset;
+  dataset << "//'" << path.c_str() << "'";
+  FILE *stream = fopen(dataset.str().c_str(), "rb+,type=record");
 
-#pragma convert("IBM-1047")
-    std::ostringstream dataset;
-    dataset << "//'" << path.c_str() << "'";
-    FILE *stream = fopen(dataset.str().c_str(), "rb+,type=record");
-#pragma convert(pop)
+  if (stream == NULL) {
+    return Napi::Boolean::New(env, false);
+  }
 
-    if (stream == NULL) {
-      args.GetReturnValue().Set(Boolean::New(isolate, false));
-      return;
-    }
-
-    fclose(stream);
-    args.GetReturnValue().Set(Boolean::New(isolate, true));
+  fclose(stream);
+  return Napi::Boolean::New(env, true);
 }
 
 
-void VsamFile::Close(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-
-  VsamFile* obj = ObjectWrap::Unwrap<VsamFile>(args.Holder());
-  if (obj->stream_ == NULL) {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "VSAM file is not open")));
+void VsamFile::Close(const Napi::CallbackInfo& args) {
+  if (stream_ == NULL) {
+    Napi::Error::New(env_, "VSAM file is not open.").ThrowAsJavaScriptException();
     return;
   }
 
-  if (fclose(obj->stream_)) {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Error closing file")));
+  if (fclose(stream_)) {
+    Napi::Error::New(env_, "Error closing file.").ThrowAsJavaScriptException();
     return;
   }
-  obj->stream_ = NULL;
+  stream_ = NULL;
 }
 
 
-void VsamFile::Delete(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-
-  if (args.Length() < 1) {
+void VsamFile::Delete(const Napi::CallbackInfo& info) {
+  if (info.Length() < 1) {
     // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
+    Napi::Error::New(env_, "Wrong number of arguments.").ThrowAsJavaScriptException();
     return;
   }
 
-  if (!args[0]->IsFunction()) {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong arguments")));
+  if (!info[0].IsFunction()) {
+    Napi::TypeError::New(env_, "Wrong arguments.").ThrowAsJavaScriptException();
     return;
   }
 
-  VsamFile* obj = ObjectWrap::Unwrap<VsamFile>(args.Holder());
   uv_work_t* request = new uv_work_t;
-  request->data = obj;
-
-  obj->cb_ = Persistent<Function>(isolate, Handle<Function>::Cast(args[0]));
-  obj->isolate_ = isolate;
-
+  request->data = this;
+  cb_ = Napi::Persistent(info[0].As<Napi::Function>());
   uv_queue_work(uv_default_loop(), request, Delete, DeleteCallback);
 }
 
 
-void VsamFile::Write(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-
-  if (args.Length() < 2) {
+void VsamFile::Write(const Napi::CallbackInfo& info) {
+  if (info.Length() < 2) {
     // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
+    Napi::Error::New(env_, "Wrong number of arguments.").ThrowAsJavaScriptException();
     return;
   }
 
-  if (!args[1]->IsFunction()) {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong arguments")));
+  if (!info[1].IsFunction()) {
+    Napi::TypeError::New(env_, "Wrong arguments.").ThrowAsJavaScriptException();
     return;
   }
 
-  Local<Object> record = args[0]->ToObject();
-  VsamFile* obj = ObjectWrap::Unwrap<VsamFile>(args.Holder());
-  obj->buf_ = malloc(obj->reclen_); //TODO: error
-  memset(obj->buf_,0,obj->reclen_);
-  char* buf = (char*)obj->buf_;
-  for(auto i = obj->layout_.begin(); i != obj->layout_.end(); ++i) {
-    Local<String> field = Local<String>::Cast(record->Get(String::NewFromUtf8(obj->isolate_, &(i->name[0]))));
-    if (!field->IsString()) {
-      isolate->ThrowException(Exception::TypeError(
-          String::NewFromUtf8(isolate, "Currently only string (including hexadecimal string) is allowed as a field value.")));
+  Napi::Object record = info[0].ToObject();
+  if (buf_) {
+    free(buf_);
+  }
+  buf_ = malloc(reclen_); //TODO: error
+  memset(buf_,0,reclen_);
+  char* buf = (char*)buf_;
+  for(auto i = layout_.begin(); i != layout_.end(); ++i) {
+    Napi::Value field = record.Get(&(i->name[0]));
+    if (!field.IsString()) {
+      Napi::TypeError::New(env_, "Currently only string (including hexadecimal string) is allowed as a field value..").ThrowAsJavaScriptException();
       return;
     }
     if (i->type == LayoutItem::STRING || i->type == LayoutItem::HEXADECIMAL) {
-      std::string key (*v8::String::Utf8Value(field));
-      transform(key.begin(), key.end(), key.begin(), [](char c) -> char {
-        __a2e_l(&c, 1);
-        return c;
-      });
+      std::string key = static_cast<std::string>(field.As<Napi::String>());
       if (i->type == LayoutItem::STRING) {
         memcpy(buf, key.c_str(), key.length() + 1);
       } else {
         hexstrToBuffer(buf, i->maxLength, key.c_str());
       }
     } else {
-      isolate->ThrowException(Exception::TypeError(
-          String::NewFromUtf8(isolate, "Unexpected JSON data type")));
+      Napi::TypeError::New(env_, "Unexpected JSON data type").ThrowAsJavaScriptException();
       return;
     }
     buf += i->maxLength;
   }
 
   uv_work_t* request = new uv_work_t;
-  request->data = obj;
-  obj->isolate_ = isolate;
+  request->data = this;
+  cb_ = Napi::Persistent(info[1].As<Napi::Function>());
   uv_queue_work(uv_default_loop(), request, Write, WriteCallback);
-  obj->cb_ = Persistent<Function>(isolate, Handle<Function>::Cast(args[1]));
 }
 
 
-void VsamFile::Update(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-
-  if (args.Length() < 2) {
+void VsamFile::Update(const Napi::CallbackInfo& info) {
+  if (info.Length() < 2) {
     // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
+    Napi::Error::New(env_, "Wrong number of arguments.").ThrowAsJavaScriptException();
     return;
   }
 
-  if (!args[1]->IsFunction()) {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong arguments")));
+  if (!info[1].IsFunction()) {
+    Napi::TypeError::New(env_, "Wrong arguments.").ThrowAsJavaScriptException();
     return;
   }
 
-  Local<Object> record = args[0]->ToObject();
-  VsamFile* obj = ObjectWrap::Unwrap<VsamFile>(args.Holder());
-  obj->buf_ = malloc(obj->reclen_); //TODO: error
-  char* buf = (char*)obj->buf_;
-  for(auto i = obj->layout_.begin(); i != obj->layout_.end(); ++i) {
-    Local<String> field = Local<String>::Cast(record->Get(String::NewFromUtf8(obj->isolate_, &(i->name[0]))));
-    if (!field->IsString()) {
-      isolate->ThrowException(Exception::TypeError(
-          String::NewFromUtf8(isolate, "Currently only string (including hexadecimal string) is allowed as a field value.")));
+  Napi::Object record = info[0].ToObject();
+  if (buf_) {
+    free(buf_);
+  }
+  buf_ = malloc(reclen_); //TODO: error
+  char* buf = (char*)buf_;
+  for(auto i = layout_.begin(); i != layout_.end(); ++i) {
+    Napi::Value field = record.Get(&(i->name[0]));
+    if (!field.IsString()) {
+      Napi::TypeError::New(env_, "Currently only string (including hexadecimal string) is allowed as a field value..").ThrowAsJavaScriptException();
       return;
     }
     if (i->type == LayoutItem::STRING || i->type == LayoutItem::HEXADECIMAL) {
-      std::string key (*v8::String::Utf8Value(field));
-      transform(key.begin(), key.end(), key.begin(), [](char c) -> char {
-        __a2e_l(&c, 1);
-        return c;
-      });
+      std::string key = static_cast<std::string>(field.As<Napi::String>());
       if (i->type == LayoutItem::STRING) {
         memcpy(buf, key.c_str(), key.length() + 1);
       } else {
@@ -722,176 +595,143 @@ void VsamFile::Update(const FunctionCallbackInfo<Value>& args) {
       buf += i->maxLength;
 
     } else {
-      isolate->ThrowException(Exception::TypeError(
-          String::NewFromUtf8(isolate, "Unexpected JSON data type")));
+      Napi::TypeError::New(env_, "Unexpected JSON data type").ThrowAsJavaScriptException();
       return;
     }
   }
 
   uv_work_t* request = new uv_work_t;
-  request->data = obj;
-
-  obj->cb_ = Persistent<Function>(isolate, Handle<Function>::Cast(args[1]));
-  obj->isolate_ = isolate;
-
+  request->data = this;
+  cb_ = Napi::Persistent(info[1].As<Napi::Function>());
   uv_queue_work(uv_default_loop(), request, Update, UpdateCallback);
 }
 
-void VsamFile::FindEq(const FunctionCallbackInfo<Value>& args) {
-  Find(args, __KEY_EQ);
+void VsamFile::FindEq(const Napi::CallbackInfo& info) {
+  Find(info, __KEY_EQ);
 }
 
-void VsamFile::FindGe(const FunctionCallbackInfo<Value>& args) {
-  Find(args, __KEY_GE);
+void VsamFile::FindGe(const Napi::CallbackInfo& info) {
+  Find(info, __KEY_GE);
 }
 
-void VsamFile::FindFirst(const FunctionCallbackInfo<Value>& args) {
-  Find(args, __KEY_FIRST);
+void VsamFile::FindFirst(const Napi::CallbackInfo& info) {
+  Find(info, __KEY_FIRST);
 }
 
-void VsamFile::FindLast(const FunctionCallbackInfo<Value>& args) {
-  Find(args, __KEY_LAST);
+void VsamFile::FindLast(const Napi::CallbackInfo& info) {
+  Find(info, __KEY_LAST);
 }
 
-void VsamFile::Find(const FunctionCallbackInfo<Value>& args, int equality) {
-  Isolate* isolate = args.GetIsolate();
-
-  std::string key = "";
+void VsamFile::Find(const Napi::CallbackInfo& info, int equality) {
+  std::string key;
   int callbackArg = 0;
   char* keybuf = NULL;
   int keybuf_len = 0;
 
   if (equality != __KEY_LAST && equality != __KEY_FIRST)  {
-    if (args.Length() < 2) {
+    if (info.Length() < 2) {
       // Throw an Error that is passed back to JavaScript
-      isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
+      Napi::Error::New(env_, "Wrong number of arguments.").ThrowAsJavaScriptException();
       return;
     }
 
-    if (args[0]->IsString()) {
-      key = std::string(*v8::String::Utf8Value(args[0]->ToString()));
-      transform(key.begin(), key.end(), key.begin(), [](char c) -> char {
-        __a2e_l(&c, 1);
-        return c;
-      });
+    if (info[0].IsString()) {
+      key = static_cast<std::string>(info[0].As<Napi::String>());
       callbackArg = 1;
-    } else if (args[0]->IsObject()) {
-      char* buf = node::Buffer::Data(args[0]->ToObject());
-      if (!args[1]->IsUint32()) {
-        isolate->ThrowException(Exception::TypeError(
-          String::NewFromUtf8(isolate, "Buffer argument must be followed by its length.")));
+    } else if (info[0].IsObject()) {
+      char* buf = info[0].As<Napi::Buffer<char>>().Data();
+      if (!info[1].IsNumber()) {
+        Napi::Error::New(env_, "Buffer argument must be followed by its length.").ThrowAsJavaScriptException();
         return;
       }
-      keybuf_len = args[1]->Uint32Value();
+      keybuf_len = info[1].As<Napi::Number>().Uint32Value();
       if (keybuf_len > 0) {
         keybuf = (char*)malloc(keybuf_len); // TODO check error
         memcpy(keybuf, buf, keybuf_len);
+      } else {
+        Napi::TypeError::New(env_, "Key buffer length must be greater than 0.").ThrowAsJavaScriptException();
+        return;
       }
       callbackArg = 2;
     } else {
-      isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "First argument must be either a string or a Buffer object.")));
+      Napi::TypeError::New(env_, "First argument must be either a string or a Buffer object.").ThrowAsJavaScriptException();
       return;
-    } 
-    if (!args[callbackArg]->IsFunction()) {
-      char err[128];
+    }
+    if (!info[callbackArg].IsFunction()) {
+      char err[64];
       if (callbackArg==1) {
         strcpy(err,"Second argument must be a function.");
       } else if (callbackArg==2) {
         strcpy(err,"Thrid argument must be a function.");
       }
-      isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, err)));
+      Napi::Error::New(env_,err).ThrowAsJavaScriptException();
       return;
     }
 
   } else {
-    if (args.Length() < 1) {
-      // Throw an Error that is passed back to JavaScript
-      isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments. 1 argument expected.")));
+    if (info.Length() < 1) {
+      Napi::Error::New(env_, "Wrong number of arguments; one argument expected.").ThrowAsJavaScriptException();
       return;
     }
-    if (!args[0]->IsFunction()) {
-      isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "First argument must be a function")));
+    if (!info[0].IsFunction()) {
+      Napi::TypeError::New(env_, "First argument must be a function.").ThrowAsJavaScriptException();
       return;
     }
   }
 
-  VsamFile* obj = ObjectWrap::Unwrap<VsamFile>(args.Holder());
   uv_work_t* request = new uv_work_t;
-  request->data = obj;
+  request->data = this;
+  cb_ = Napi::Persistent(info[callbackArg].As<Napi::Function>());
 
-  obj->cb_ = Persistent<Function>(isolate, Handle<Function>::Cast(args[callbackArg]));
-  obj->isolate_ = isolate;
-  if (!keybuf)
-    obj->key_ = key;
-  else {
-    obj->keybuf_ = keybuf;
-    obj->keybuf_len_ = keybuf_len;
+  if (!keybuf) {
+    key_ = key;
+  } else {
+    key_ = "";
+    keybuf_ = keybuf;
+    keybuf_len_ = keybuf_len;
   }
-  obj->equality_ = equality;
+  equality_ = equality;
 
   uv_queue_work(uv_default_loop(), request, Find, ReadCallback);
 }
 
-void VsamFile::Read(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-
-  if (args.Length() < 1) {
+void VsamFile::Read(const Napi::CallbackInfo& info) {
+  if (info.Length() < 1) {
     // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
+    Napi::Error::New(env_, "Wrong number of arguments.").ThrowAsJavaScriptException();
     return;
   }
 
-  if (!args[0]->IsFunction()) {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong arguments")));
+  if (!info[0].IsFunction()) {
+    Napi::TypeError::New(env_, "Wrong arguments.").ThrowAsJavaScriptException();
     return;
   }
 
-  VsamFile* obj = ObjectWrap::Unwrap<VsamFile>(args.Holder());
   uv_work_t* request = new uv_work_t;
-  request->data = obj;
-
-  obj->cb_ = Persistent<Function>(isolate, Handle<Function>::Cast(args[0]));
-  obj->isolate_ = isolate;
-
+  request->data = this;
+  cb_ = Napi::Persistent(info[0].As<Napi::Function>());
   uv_queue_work(uv_default_loop(), request, Read, ReadCallback);
 }
 
 
-void VsamFile::Dealloc(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-
-  if (args.Length() < 1) {
+void VsamFile::Dealloc(const Napi::CallbackInfo& info) {
+  if (info.Length() < 1) {
     // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
+    Napi::Error::New(env_, "Wrong number of arguments.").ThrowAsJavaScriptException();
     return;
   }
 
-  if (!args[0]->IsFunction()) {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong arguments")));
+  if (!info[0].IsFunction()) {
+    Napi::TypeError::New(env_, "Wrong arguments.").ThrowAsJavaScriptException();
     return;
   }
-
-  VsamFile* obj = ObjectWrap::Unwrap<VsamFile>(args.Holder());
-  if (obj->stream_ != NULL) {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Cannot dealloc an open VSAM file")));
+  if (stream_ != NULL) {
+    Napi::Error::New(env_, "Cannot dealloc an open VSAM file.").ThrowAsJavaScriptException();
     return;
   }
   uv_work_t* request = new uv_work_t;
-  request->data = obj;
-
-  obj->cb_ = Persistent<Function>(isolate, Handle<Function>::Cast(args[0]));
-  obj->isolate_ = isolate;
-
+  cb_ = Napi::Persistent(info[0].As<Napi::Function>());
+  request->data = this;
   uv_queue_work(uv_default_loop(), request, Dealloc, DeallocCallback);
 }
 
@@ -903,17 +743,13 @@ static const char* hexstrToBuffer (char* hexbuf, int buflen, const char* hexstr)
    for (i=0,j=0; i<hexstrlen-(hexstrlen%2); ) {
      xx[0] = hexstr[i++];
      xx[1] = hexstr[i++];
-#pragma convert("IBM-1047")
      sscanf(xx,"%2x", &x);
-#pragma convert(pop)
      hexbuf[j++] = x;
    }
    if (hexstrlen%2) {
      xx[0] = hexstr[i];
-#pragma convert("IBM-1047")
      xx[1] = '0';
      sscanf(xx,"%2x", &x);
-#pragma convert(pop)
      hexbuf[j] = x;
    }
    return hexbuf;
@@ -923,21 +759,14 @@ static const char* bufferToHexstr (char* hexstr, const char* hexbuf, const int h
    int i, j;
    for (i=0,j=0; i<hexbuflen; i++,j+=2) {
      if (hexbuf[i]==0) {
-#pragma convert("IBM-1047")
        memset(hexstr+j,'0',2);
-#pragma convert(pop)
      } else {
-#pragma convert("IBM-1047")
        sprintf(hexstr+j,"%02x", hexbuf[i]);
-#pragma convert(pop)
      }
    }
-#pragma convert("IBM-1047")
    //remove trailing '0's, unless value is '00'
    while(--j>2 && hexstr[j]=='0')
      ;
-#pragma convert(pop)
    hexstr[++j] = 0;
-   __e2a_l(hexstr,strlen(hexstr));
    return hexstr;
 }

--- a/VsamFile.h
+++ b/VsamFile.h
@@ -4,22 +4,21 @@
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 */
 
-#ifndef VSAM_H
-#define VSAM_H
-
-#include <node.h>
+#pragma once
+#include <napi.h>
+#include <uv.h>
 #include <node_object_wrap.h>
 #include <uv.h>
 #include <string>
 
-class VsamFile : public node::ObjectWrap {
+class VsamFile : public Napi::ObjectWrap<VsamFile> {
  public:
-  static void Init(v8::Isolate* isolate);
-  static void OpenSync(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void AllocSync(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Exist(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static v8::Persistent<v8::Function> OpenSyncConstructor;
-  static v8::Persistent<v8::Function> AllocSyncConstructor;
+  static void Init(Napi::Env env, Napi::Object exports);
+  VsamFile(const Napi::CallbackInfo& info);
+
+  static Napi::Value OpenSync(const Napi::CallbackInfo& info);
+  static Napi::Value AllocSync(const Napi::CallbackInfo& info);
+  static Napi::Boolean Exist(const Napi::CallbackInfo& info);
   ~VsamFile();
 
  private:
@@ -32,27 +31,24 @@ class VsamFile : public node::ObjectWrap {
     std::vector<char> name;
     int maxLength;
     DataType type;
-    LayoutItem(v8::String::Utf8Value& n, int m, DataType t) :
+    LayoutItem(std::string& n, int m, DataType t) :
       name(n.length()), maxLength(m), type(t) {
-      memcpy(&name[0], *n, n.length());
+      memcpy(&name[0], n.data(), n.length());
     }
   };
 
-  explicit VsamFile(std::string&, std::vector<LayoutItem>&,
-                    v8::Isolate* isolate, bool alloc, int key_i);
-
   /* Entry point from Javascript */
-  static void Close(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Read(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Find(const v8::FunctionCallbackInfo<v8::Value>& args, int equality);
-  static void FindEq(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void FindGe(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void FindFirst(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void FindLast(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Update(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Write(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Delete(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Dealloc(const v8::FunctionCallbackInfo<v8::Value>& args);
+  void Close(const Napi::CallbackInfo& info);
+  void Read(const Napi::CallbackInfo& info);
+  void Find(const Napi::CallbackInfo& info, int equality);
+  void FindEq(const Napi::CallbackInfo& info);
+  void FindGe(const Napi::CallbackInfo& info);
+  void FindFirst(const Napi::CallbackInfo& info);
+  void FindLast(const Napi::CallbackInfo& info);
+  void Update(const Napi::CallbackInfo& info);
+  void Write(const Napi::CallbackInfo& info);
+  void Delete(const Napi::CallbackInfo& info);
+  void Dealloc(const Napi::CallbackInfo& info);
 
   /* Work functions */
   static void Open(uv_work_t* req);
@@ -65,7 +61,6 @@ class VsamFile : public node::ObjectWrap {
   static void Delete(uv_work_t* req);
 
   /* Work callback functions */
-  v8::Persistent<v8::Function, v8::CopyablePersistentTraits<v8::Function>> cb_;
   static void OpenCallback(uv_work_t* req, int statusj);
   static void AllocCallback(uv_work_t* req, int statusj);
   static void DeallocCallback(uv_work_t* req, int statusj);
@@ -75,11 +70,12 @@ class VsamFile : public node::ObjectWrap {
   static void DeleteCallback(uv_work_t* req, int status);
 
   /* Private methods */
-  static void SetPrototypeMethods(v8::Local<v8::FunctionTemplate>& tpl);
-  static void Construct(const v8::FunctionCallbackInfo<v8::Value>& args, bool alloc);
+  static Napi::Value Construct(const Napi::CallbackInfo& info, bool alloc);
 
   /* Data */
-  v8::Isolate* isolate_;
+  static Napi::FunctionReference constructor_;
+  Napi::Env env_;
+  Napi::FunctionReference cb_;
   std::string path_;
   std::string key_;
   char* keybuf_;
@@ -93,5 +89,3 @@ class VsamFile : public node::ObjectWrap {
   int equality_;
   std::string errmsg_;
 };
-
-#endif

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,30 @@
   "targets": [
     {
       "target_name": "vsam.js",
+      "cflags!": [ "-fno-exceptions", "-qxclang=-fexec-charset=ISO8859-1" ],
+      "cflags_cc!": [ "-fno-exceptions", "-qxclang=-fexec-charset=ISO8859-1" ],
+      "cflags": [ "-qascii" ],
+      "cflags_cc": [ "-qascii" ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
+      "include_dirs": [
+         "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      "dependencies": [
+         "<!(node -p \"require('node-addon-api').gyp\")"
+      ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
       "sources": [ "vsam.cpp", "VsamFile.cpp" ]
     }
   ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,8 @@
       "msvs_settings": {
         "VCCLCompilerTool": { "ExceptionHandling": 1 },
       },
-      "sources": [ "vsam.cpp", "VsamFile.cpp" ]
+      "sources": [ "vsam.cpp", "VsamFile.cpp" ],
+      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsam.js",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Interact with VSAM files on z/OS",
   "main": "index.js",
   "repository": "ibmruntimes/vsam.js",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bindings": "1.2.x",
+    "node-addon-api": "^1.7.1",
     "node-gyp": "^3.6.0"
   },
   "devDependencies": {

--- a/test/ksds2.js
+++ b/test/ksds2.js
@@ -134,32 +134,29 @@ describe("Key Sequenced Dataset #2", function() {
       assert.equal(record.key, "a1b2c3d4", "1. record has been created");
       assert.equal(record.name, "JOHN", "created record has correct name");
       assert.equal(record.amount, "1234", "created record has correct amount");
-      expect(file.close()).to.not.throw;
-      done();
-    });
-    file.findlast((record, err) => {
-      assert.ifError(err);
-      assert.equal(record.key, "e5f6789afabcd", "2. record has been created");
-      assert.equal(record.name, "JIM", "created record has correct name");
-      assert.equal(record.amount, "9876543210", "created record has correct amount");
-      expect(file.close()).to.not.throw;
-      done();
-    });
-    file.findfirst((record, err) => {
-      assert.ifError(err);
-      assert.equal(record.key, "a1b2c3d4", "3. record has been created");
-      assert.equal(record.name, "JOHN", "created record has correct name");
-      assert.equal(record.amount, "1234", "created record has correct amount");
-      expect(file.close()).to.not.throw;
-      done();
-    });
-    file.findge("43b2c3d0", (record, err) => {
-      assert.ifError(err);
-      assert.equal(record.key, "a1b2c3d4", "4. record has been created");
-      assert.equal(record.name, "JOHN", "created record has correct name");
-      assert.equal(record.amount, "1234", "created record has correct amount");
-      expect(file.close()).to.not.throw;
-      done();
+
+      file.findlast((record, err) => {
+        assert.ifError(err);
+        assert.equal(record.key, "e5f6789afabcd", "2. record has been created");
+        assert.equal(record.name, "JIM", "created record has correct name");
+        assert.equal(record.amount, "987654321", "created record has correct amount");
+
+        file.findfirst((record, err) => {
+          assert.ifError(err);
+          assert.equal(record.key, "a1b2c3d4", "3. record has been created");
+          assert.equal(record.name, "JOHN", "created record has correct name");
+          assert.equal(record.amount, "1234", "created record has correct amount");
+        
+          file.findge("43b2c3d0", (record, err) => {
+            assert.ifError(err);
+            assert.equal(record.key, "a1b2c3d4", "4. record has been created");
+            assert.equal(record.name, "JOHN", "created record has correct name");
+            assert.equal(record.amount, "1234", "created record has correct amount");
+            expect(file.close()).to.not.throw;
+            done();
+          });
+        });
+      });
     });
   });
 

--- a/vsam.cpp
+++ b/vsam.cpp
@@ -4,22 +4,19 @@
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 */
 
-#include <node.h>
+#include <napi.h>
 #include "VsamFile.h"
 
-using v8::FunctionCallbackInfo;
-using v8::Isolate;
-using v8::Local;
-using v8::Object;
-using v8::String;
-using v8::Value;
+Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
+  VsamFile::Init(env,exports);
 
-void InitAll(Local<Object> exports, Local<Object> module) {
-  VsamFile::Init(exports->GetIsolate());
-
-  NODE_SET_METHOD(exports, "openSync", VsamFile::OpenSync);
-  NODE_SET_METHOD(exports, "allocSync", VsamFile::AllocSync);
-  NODE_SET_METHOD(exports, "exist", VsamFile::Exist);
+  exports.Set(Napi::String::New(env, "openSync"),
+              Napi::Function::New(env, VsamFile::OpenSync));
+  exports.Set(Napi::String::New(env, "allocSync"),
+              Napi::Function::New(env, VsamFile::AllocSync));
+  exports.Set(Napi::String::New(env, "exist"),
+              Napi::Function::New(env, VsamFile::Exist));
+  return exports;
 }
 
-NODE_MODULE(vsam, InitAll)
+NODE_API_MODULE(vsam, InitAll)


### PR DESCRIPTION
#### Checklist
- [x] npm install && npm test passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Description of change
- convert vsam.js npm to use N-API
- resolve memory leak issues
- adjust test to sequence a bunch of find* tests (VsamFile class currently not desgined for multiple ops in parallel)