### PR TITLE
convert attr value to string instead of enforcing

### DIFF
--- a/VsamFile.cpp
+++ b/VsamFile.cpp
@@ -536,14 +536,10 @@ void VsamFile::Write(const Napi::CallbackInfo& info) {
   char* buf = (char*)buf_;
   for(auto i = layout_.begin(); i != layout_.end(); ++i) {
     Napi::Value field = record.Get(&(i->name[0]));
-    if (!field.IsString()) {
-      Napi::TypeError::New(env_, "Currently only string (including hexadecimal string) is allowed as a field value..").ThrowAsJavaScriptException();
-      return;
-    }
     if (i->type == LayoutItem::STRING || i->type == LayoutItem::HEXADECIMAL) {
-      std::string key = static_cast<std::string>(field.As<Napi::String>());
+      std::string key = static_cast<std::string>(Napi::String (env_, field.ToString()));
       if (i->type == LayoutItem::STRING) {
-        memcpy(buf, key.c_str(), key.length() + 1);
+        memcpy(buf, key.c_str(), key.length());
       } else {
         hexstrToBuffer(buf, i->maxLength, key.c_str());
       }


### PR DESCRIPTION
#### Checklist
- [x] npm install && npm test passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Description of change
vsam.js currently supports string and hexadecimal data types 

In the zTrial VsamApp `boot.js`, attribute values for the 'key' field were not quoted, but could be processed correctly as a string, until this change
https://github.com/ibmruntimes/vsam.js/commit/fcbbbfb0c14bed3b80039a4147b6e4540ad6f06a
in which the code I added included checking that the field's value is a string. This is causing VsamApp zTrial to fail unless `key` each values are quoted:
```
function populateVSAM(){
    var records = [
      {key: 1, name: "Mike", gender: "Male"},
...
      {key: 5, name: "Iris", gender: "Female"}
    ];
```