### PR TITLE
convert attr value to string instead of enforcing - cont'd for Update

### DIFF
--- a/VsamFile.cpp
+++ b/VsamFile.cpp
@@ -574,17 +574,14 @@ void VsamFile::Update(const Napi::CallbackInfo& info) {
     free(buf_);
   }
   buf_ = malloc(reclen_); //TODO: error
+  memset(buf_,0,reclen_);
   char* buf = (char*)buf_;
   for(auto i = layout_.begin(); i != layout_.end(); ++i) {
     Napi::Value field = record.Get(&(i->name[0]));
-    if (!field.IsString()) {
-      Napi::TypeError::New(env_, "Currently only string (including hexadecimal string) is allowed as a field value..").ThrowAsJavaScriptException();
-      return;
-    }
     if (i->type == LayoutItem::STRING || i->type == LayoutItem::HEXADECIMAL) {
-      std::string key = static_cast<std::string>(field.As<Napi::String>());
+      std::string key = static_cast<std::string>(Napi::String (env_, field.ToString()));
       if (i->type == LayoutItem::STRING) {
-        memcpy(buf, key.c_str(), key.length() + 1);
+        memcpy(buf, key.c_str(), key.length());
       } else {
         hexstrToBuffer(buf, i->maxLength, key.c_str());
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsam.js",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Interact with VSAM files on z/OS",
   "main": "index.js",
   "repository": "ibmruntimes/vsam.js",


### PR DESCRIPTION
#### Checklist
- [x] npm install && npm test passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Description of change
As in https://github.com/ibmruntimes/vsam.js/pull/19 this change supports updates without enforcing string attribute values.