### PR TITLE
pass constructor.New() a copy of buffer instead of an allocated buffer

### DIFF
--- a/VsamFile.cpp
+++ b/VsamFile.cpp
@@ -429,7 +429,7 @@ Napi::Value VsamFile::Construct(const Napi::CallbackInfo& info, bool alloc) {
   Napi::HandleScope scope(env);
   Napi::Object obj = constructor_.New({
     Napi::String::New(env, path),
-    Napi::Buffer<std::vector<LayoutItem>>::New(env, &layout, layout.size()),
+    Napi::Buffer<std::vector<LayoutItem>>::Copy(env, &layout, layout.size()),
     Napi::Boolean::New(env, alloc),
     Napi::Number::New(env, key_i)});
   VsamFile* p = Napi::ObjectWrap<VsamFile>::Unwrap(obj);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsam.js",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Interact with VSAM files on z/OS",
   "main": "index.js",
   "repository": "ibmruntimes/vsam.js",


### PR DESCRIPTION
#### Checklist
- [x] npm install && npm test passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Description of change
This PR fixes a bug exposed by the new V8 ArrayBuffer and BackingStore behaviour. When creating the VsamFile object, we passed to constructor.New a Napi::Buffer wrapper of T*data that's points to a variable in the stack, so subsequent calls resulted in the same address in different BackingStore's, which is not allowed. And since Napi::Buffer doesn't assume ownership of the data, it never gets freed, so there was also a memory leak.

This is resolved here by passing a Copy() of the layout data (rather than New()) - this should also allow garbage collector to clean it.
