### PR TITLE
fix bugs when finding & returning hexadecimal fields plus other buffer issue

### DIFF
--- a/VsamFile.h
+++ b/VsamFile.h
@@ -32,8 +32,8 @@ class VsamFile : public Napi::ObjectWrap<VsamFile> {
     int maxLength;
     DataType type;
     LayoutItem(std::string& n, int m, DataType t) :
-      name(n.length()), maxLength(m), type(t) {
-      memcpy(&name[0], n.data(), n.length());
+      name(n.length()+1), maxLength(m), type(t) {
+      strcpy(&name[0], n.c_str());
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsam.js",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Interact with VSAM files on z/OS",
   "main": "index.js",
   "repository": "ibmruntimes/vsam.js",


### PR DESCRIPTION
#### Checklist
- [x] npm install && npm test passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Description of change
The main purpose of this PR is to resolve an issue reported by Jack Henry, in which the trailing low nibble 0 of a non-0 byte of the hexadecimal data returned was truncated. Other bugs were found and resolved here as listed below.

- don't truncate the low nibble 0 of a non-zero byte after reading a hex field
- null-terminate the record data in the read callback 
- fix arguments in record.Set() for the callback
- allocate an extra byte when calling hexstrToBuffer() in case hexstr length % 2 == 1 (as it may add a low nibble '0')
- null-terminate the char* argument in Napi::Object::Set() & Get()

- test that the low nibble 0 of a non-zero byte is not truncated after reading a hex field
- test that trailing '00's in hex field are truncated when read