### PR TITLE
support new optional open-mode argument in openSync()

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,14 @@ var vsamObj = vsam.openSync("VSAM.DATASET.NAME", JSON.parse(fs.readFileSync('sch
 
 * The first argument is the name of an existing VSAM dataset.
 * The second argument is the JSON object derived from the schema file.
-* The value returned is a vsam dataset handle. The rest of this readme describes the operations that can be performed on this object.
+* The optional third argument, if specified, is the fopen() mode; default is 'ab+,type=record' if none is specified.
+* The value returned is a VSAM dataset handle. The rest of this readme describes the operations that can be performed on this object.
 * Usage notes:
+  * If the third argument is specified, it is passed as-is to C/C++ library function fopen().
+  * To open a non-empty VSAM dataset in read-only mode, specify 'rb,type=record' as the third argument.
   * On error, this function with throw an exception.
 
-## Check if vsam dataset exists
+## Check if VSAM dataset exists
 
 ```js
 const vsam = require('vsam');
@@ -121,7 +124,7 @@ if (vsam.exist("VSAM.DATASET.NAME")) {
 * The first argument is the name of an existing VSAM dataset.
 * Boolean value is returned indicating whether dataset exists or not.
 
-## Closing a vsam dataset
+## Closing a VSAM dataset
 
 ```js
 vsamObj.close((err) => { /* Handle error. */ });
@@ -129,7 +132,7 @@ vsamObj.close((err) => { /* Handle error. */ });
 
 * The first argument is a callback function containing an error object if the close operation failed.
 
-## Reading a record from a vsam dataset
+## Reading a record from a VSAM dataset
 
 ```js
 vsamObj.read((record, err) => { 
@@ -153,7 +156,7 @@ The following data types are currently supported:
 
 See [test/test2.json](https://github.com/ibmruntimes/vsam.js/blob/master/test/test2.json) and [test/ksds2.js](https://github.com/ibmruntimes/vsam.js/blob/master/test/ksds2.js) for an example covering both types.
 
-## Writing a record to a vsam dataset
+## Writing a record to a VSAM dataset
 
 ```js
 vsamObj.write(record, (err) => { 
@@ -167,7 +170,7 @@ vsamObj.write(record, (err) => {
   * The write operation advances the cursor by one record length after the newly written record.
   * The write operation will overwrite any existing record with the same key.
 
-## Finding a record in a vsam dataset
+## Finding a record in a VSAM dataset
 
 ```js
 vsamObj.find(recordKey, (record, err) => { 
@@ -195,7 +198,7 @@ vsamObj.findfirst(recordKey, (record, err) => {
   * The find operation will place the cursor at the queried record (if found).
   * The record object in the callback will by null if the query failed to retrieve a record.
   
-## Updating a record in a vsam dataset
+## Updating a record in a VSAM dataset
 
 ```js
 vsamObj.update(record, (err) => { 
@@ -209,7 +212,7 @@ vsamObj.update(record, (err) => {
 * Usage notes:
   * The update operation will write over the record currently under the cursor.
   
-## Deleting a record from a vsam dataset
+## Deleting a record from a VSAM dataset
 
 ```js
 vsamObj.delete((err) => { /* Handle error. */ });
@@ -221,7 +224,7 @@ vsamObj.delete((err) => { /* Handle error. */ });
   * This will usually be placed inside the callback of a find operation. The find operation places
     the cursor on the desired record and the subsequent delete operation deletes it.
 
-## Deallocating a vsam dataset
+## Deallocating a VSAM dataset
 
 ```js
 vsamObj.dealloc((err) => { /* Handle error. */ });

--- a/VsamFile.cpp
+++ b/VsamFile.cpp
@@ -316,6 +316,7 @@ VsamFile::VsamFile(const Napi::CallbackInfo& info)
     }
     stream_ = fopen(dataset.str().c_str(), "ab+,type=record");
     if (stream_ == NULL) {
+      perror("fopen");
       errmsg_ = "Failed to open new dataset";
       lastrc_ = -1;
       return;

--- a/VsamFile.h
+++ b/VsamFile.h
@@ -77,6 +77,7 @@ class VsamFile : public Napi::ObjectWrap<VsamFile> {
   Napi::Env env_;
   Napi::FunctionReference cb_;
   std::string path_;
+  std::string omode_;
   std::string key_;
   char* keybuf_;
   int keybuf_len_;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsam.js",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Interact with VSAM files on z/OS",
   "main": "index.js",
   "repository": "ibmruntimes/vsam.js",

--- a/test/ksds2.js
+++ b/test/ksds2.js
@@ -227,11 +227,20 @@ describe("Key Sequenced Dataset #2", function() {
     done();
   });
 
-  it("return error for non-existent dataset", function(done) {
+  it("return error for invalid dataset access", function(done) {
     expect(() => {
-      vsam.openSync("A.B",
+      vsam.openSync("A9y8o2.X", // test will fail if it actually exists and user can access
                     JSON.parse(fs.readFileSync('test/test2.json')));
-    }).to.throw(/The specified file name could not be located/);
+    }).to.throw(/An error occurred when attempting to define a file to the system/);
+    done();
+  });
+
+  it("return error for invalid dataset name", function(done) {
+    expect(() => {
+      const testSet = `${uid}.A.B._`;
+      vsam.openSync(testSet,
+                    JSON.parse(fs.readFileSync('test/test2.json')));
+    }).to.throw(/An invalid file name was specified/);
     done();
   });
 

--- a/test/ksds2.js
+++ b/test/ksds2.js
@@ -58,7 +58,7 @@ describe("Key Sequenced Dataset #2", function() {
 
   it("create an empty dataset", function(done) {
     var file = vsam.allocSync(testSet,
-                             JSON.parse(fs.readFileSync('test/test2.json')))
+                             JSON.parse(fs.readFileSync('test/test2.json')));
     expect(file).not.be.null;
     expect(file.close()).to.not.throw;
     done();
@@ -71,7 +71,7 @@ describe("Key Sequenced Dataset #2", function() {
 
   it("open and close the existing dataset", function(done) {
     var file = vsam.openSync(testSet,
-                             JSON.parse(fs.readFileSync('test/test2.json')))
+                             JSON.parse(fs.readFileSync('test/test2.json')));
     expect(file).to.not.be.null;
     expect(file.close()).to.not.throw;
     done();
@@ -79,7 +79,7 @@ describe("Key Sequenced Dataset #2", function() {
 
  it("write new record, provide key as Buffer.toString('hex')", function(done) {
     var file = vsam.openSync(testSet,
-                             JSON.parse(fs.readFileSync('test/test2.json')))
+                             JSON.parse(fs.readFileSync('test/test2.json')));
     const keybuf = Buffer.from([0xa1, 0xb2, 0xc3, 0xd4]);
     record = {
       key: keybuf.toString('hex'),
@@ -95,7 +95,7 @@ describe("Key Sequenced Dataset #2", function() {
 
  it("write another new record, provide key as Buffer", function(done) {
     var file = vsam.openSync(testSet,
-                             JSON.parse(fs.readFileSync('test/test2.json')))
+                             JSON.parse(fs.readFileSync('test/test2.json')));
 // not supported yet:
 //    key: Buffer.from([0xe5, 0xf6, 0x78, 0x9a, 0xfa, 0xbc, 0xd]),
 //    key: Buffer.from([0xe5, 0xf6, 0x78, 0x9a, 0xfa, 0xbc, 0xd]).toString('hex'),
@@ -114,7 +114,7 @@ describe("Key Sequenced Dataset #2", function() {
 
   it("read a record and verify properties", function(done) {
     var file = vsam.openSync(testSet,
-                             JSON.parse(fs.readFileSync('test/test2.json')))
+                             JSON.parse(fs.readFileSync('test/test2.json')));
     file.read( (record, err) => {
       assert.ifError(err);
       expect(record).to.not.be.null;
@@ -128,7 +128,7 @@ describe("Key Sequenced Dataset #2", function() {
 
   it("find existing record using Buffer and hexadecimal string as key, and verify data", function(done) {
     var file = vsam.openSync(testSet,
-                             JSON.parse(fs.readFileSync('test/test2.json')))
+                             JSON.parse(fs.readFileSync('test/test2.json')));
     const keybuf = Buffer.from([0xa1, 0xb2, 0xc3, 0xd4]);
     file.find(keybuf, keybuf.length, (record, err) => {
       assert.ifError(err);
@@ -163,7 +163,7 @@ describe("Key Sequenced Dataset #2", function() {
 
   it("write new record after read", function(done) {
     var file = vsam.openSync(testSet,
-                             JSON.parse(fs.readFileSync('test/test2.json')))
+                             JSON.parse(fs.readFileSync('test/test2.json')));
     file.read((record, err) => {
       // trailing 00 will be truncated, key up to 'c' matches JIM's, whose key is then followed by 'd'
       record.key = "e5f6789afabc00";
@@ -185,7 +185,7 @@ describe("Key Sequenced Dataset #2", function() {
 
   it("delete existing record", function(done) {
     var file = vsam.openSync(testSet,
-                             JSON.parse(fs.readFileSync('test/test2.json')))
+                             JSON.parse(fs.readFileSync('test/test2.json')));
 //  const keybuf = Buffer.from([0xa1, 0xb2, 0xc3, 0xd4]);
     const keybuf = Buffer.from([0xA1, 0xB2, 0xc3, 0xD4]);
     file.find(keybuf, keybuf.length, (record, err) => {
@@ -206,14 +206,14 @@ describe("Key Sequenced Dataset #2", function() {
 
   it("reads all records until the end", function(done) {
     var file = vsam.openSync(testSet,
-                             JSON.parse(fs.readFileSync('test/test2.json')))
+                             JSON.parse(fs.readFileSync('test/test2.json')));
     readUntilEnd(file, done);
   });
 
   it("open a vsam file with incorrect key length", function(done) {
     expect(() => {
       vsam.openSync(testSet,
-                    JSON.parse(fs.readFileSync('test/test-error.json')))
+                    JSON.parse(fs.readFileSync('test/test-error.json')));
     }).to.throw(/Incorrect key length/);
     done();
   });
@@ -221,14 +221,21 @@ describe("Key Sequenced Dataset #2", function() {
   it("return error for non-existent dataset", function(done) {
     expect(() => {
       vsam.openSync("A..B",
-                    JSON.parse(fs.readFileSync('test/test2.json')))
+                    JSON.parse(fs.readFileSync('test/test2.json')));
     }).to.throw(/Invalid dataset name/);
     done();
   });
 
+  it("open in read-only mode, reads all records until the end", function(done) {
+    var file = vsam.openSync(testSet,
+                             JSON.parse(fs.readFileSync('test/test2.json')),
+                             "rb,type=record");
+    readUntilEnd(file, done);
+  });
+
   it("update existing record and delete it", function(done) {
     var file = vsam.openSync(testSet,
-                             JSON.parse(fs.readFileSync('test/test2.json')))
+                             JSON.parse(fs.readFileSync('test/test2.json')));
     file.find("e5f6789afabc", (record, err) => {
       assert.ifError(err);
       record.name = "KEVIN";
@@ -248,10 +255,9 @@ describe("Key Sequenced Dataset #2", function() {
       });
     });
   });
-
   it("deallocate a dataset", function(done) {
     var file = vsam.openSync(testSet,
-                             JSON.parse(fs.readFileSync('test/test2.json')))
+                             JSON.parse(fs.readFileSync('test/test2.json')));
     expect(file.close()).to.not.throw;
     file.dealloc((err) => {
       assert.ifError(err);

--- a/test/ksds2.js
+++ b/test/ksds2.js
@@ -77,6 +77,15 @@ describe("Key Sequenced Dataset #2", function() {
     done();
   });
 
+  it("return error for opening empty dataset in read-only mode", function(done) {
+    expect(() => {
+      vsam.openSync(testSet,
+                    JSON.parse(fs.readFileSync('test/test2.json')),
+                    'rb,type=record');
+    }).to.throw(/Failed to open dataset/);
+    done();
+  });
+
  it("write new record, provide key as Buffer.toString('hex')", function(done) {
     var file = vsam.openSync(testSet,
                              JSON.parse(fs.readFileSync('test/test2.json')));
@@ -220,9 +229,17 @@ describe("Key Sequenced Dataset #2", function() {
 
   it("return error for non-existent dataset", function(done) {
     expect(() => {
+      vsam.openSync("A.B",
+                    JSON.parse(fs.readFileSync('test/test2.json')));
+    }).to.throw(/The specified file name could not be located/);
+    done();
+  });
+
+  it("return error for invalid dataset name", function(done) {
+    expect(() => {
       vsam.openSync("A..B",
                     JSON.parse(fs.readFileSync('test/test2.json')));
-    }).to.throw(/Invalid dataset name/);
+    }).to.throw(/invalid file name/);
     done();
   });
 


### PR DESCRIPTION
#### Checklist
- [x] npm install && npm test passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Description of change
This PR is to enable user to open a VSAM dataset in read-only mode, by supporting an optional third argument to openSync() API. 

As before, the file is first opened with 'rb+,type=record' to check if it exists, and if it does and an open-mode argument is specified, then the file is freopen()'d with the given mode, or with the default 'ab+,type=record' if no open-mode was given. 

No validation of the open-mode argument string is done. If an error occurred, a perror("freopen") and perror("fopen") will now display the error (in addition to the current "Failed to open dataset" in the callback) for both openSync() and allocSync().