### PR TITLE
remove unneeded node-gyp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bindings": "1.2.x",
-    "node-addon-api": "^1.7.1",
-    "node-gyp": "^3.6.0"
+    "node-addon-api": "^1.7.1"
   },
   "devDependencies": {
     "async": "^1.5.0",


### PR DESCRIPTION
Likely the node-gyp dependency was added at the time because it wasn't shipped with Node.js on z/OS. The old node-gyp version 3.6.0 didn't support Python 3, and caused a failure during npm install.