### PR TITLE
resolve errors and warnings when building with clang

### DIFF
--- a/VsamFile.cpp
+++ b/VsamFile.cpp
@@ -9,7 +9,9 @@
 #include <dynit.h>
 #include <numeric>
 #include <sstream>
+#include <algorithm>
 #include <unistd.h>
+#include <assert.h>
 
 // VSAM register 15 for interpreting some of the errors:
 // https://www.ibm.com/support/knowledgecenter/SSB27H_6.2.0/fa2mc2_vsevsam_return_and_error_codes.html
@@ -18,6 +20,8 @@
 static std::string &createErrorMsg(std::string &errmsg, int err, int err2,
                                    int r15, const std::string &errPrefix);
 
+#if 0
+// Currently not used, but keep it in case it's needed.
 static void print_amrc() {
   __amrc_type currErr = *__amrc;
   printf("R15 value = %d\n", currErr.__code.__feedback.__rc);
@@ -25,10 +29,11 @@ static void print_amrc() {
   printf("RBA = %d\n", currErr.__RBA);
   printf("Last op = %d\n", currErr.__last_op);
 }
+#endif
 
 int VsamFile::freadRecord(UvWorkData *pdata, int *pr15, bool expectEOF,
                           const char *pDisplayPrefix, const char *pErrPrefix) {
-  int nread = fread(pdata->recbuf_, 1, reclen_, stream_);
+  size_t nread = fread(pdata->recbuf_, 1, reclen_, stream_);
   *pr15 = R15;
   if (feof(stream_)) {
     if (expectEOF)
@@ -115,8 +120,6 @@ int VsamFile::FindExecute(UvWorkData *pdata, const char *buf, int buflen) {
 
 void VsamFile::FindExecute(UvWorkData *pdata) {
   DCHECK(pdata->rc_ != 0);
-  char *buf;
-
   DCHECK(pdata->recbuf_ == nullptr);
   pdata->recbuf_ = (char *)malloc(reclen_);
   DCHECK(pdata->recbuf_ != nullptr);
@@ -134,7 +137,7 @@ void VsamFile::FindUpdateExecute(UvWorkData *pdata) {
   memcpy(pupdrecbuf, pdata->recbuf_, reclen_);
 
   pdata->rc_ = FindExecute(pdata, pdata->keybuf_, pdata->keybuf_len_);
-  int nread, r15;
+  int r15;
 
   for (pdata->count_ = 0; pdata->rc_ == 0;) {
     for (auto i = pdata->pFieldsToUpdate_->begin();
@@ -202,7 +205,7 @@ void VsamFile::FindDeleteExecute(UvWorkData *pdata) {
   DCHECK(pdata->recbuf_ != nullptr);
 
   pdata->rc_ = FindExecute(pdata, pdata->keybuf_, pdata->keybuf_len_);
-  int nread, r15;
+  int r15;
 
   for (pdata->count_ = 0; pdata->rc_ == 0;) {
     pdata->rc_ = 1;
@@ -290,16 +293,16 @@ void VsamFile::DeleteExecute(UvWorkData *pdata) {
 }
 
 void VsamFile::displayRecord(const char *recbuf, const char *pSuffix) {
-  int i, pos = 0;
+  int pos = 0;
   fprintf(stderr, "REC=|");
   for (auto l = layout_.begin(); l != layout_.end(); ++l) {
     // fprintf(stderr, "%s:", l->name.c_str());
     if (l->type == LayoutItem::HEXADECIMAL) {
-      for (i = 0; i < l->maxLength; i++, pos++)
+      for (size_t i = 0; i < l->maxLength; i++, pos++)
         fprintf(stderr, "%02x", recbuf[pos]);
     } else {
       assert(l->type == LayoutItem::STRING);
-      for (i = 0; i < l->maxLength; i++, pos++)
+      for (size_t i = 0; i < l->maxLength; i++, pos++)
         fprintf(stderr, "%c", recbuf[pos] ? recbuf[pos] : '.');
     }
     fprintf(stderr, "|");
@@ -317,7 +320,7 @@ void VsamFile::WriteExecute(UvWorkData *pdata) {
     fprintf(stderr, "%02x ", pdata->recbuf_[i]);
   fprintf(stderr, "\n");
 #endif
-  int nelem = fwrite(pdata->recbuf_, 1, reclen_, stream_);
+  size_t nelem = fwrite(pdata->recbuf_, 1, reclen_, stream_);
   int r15 = R15;
 #ifdef DEBUG
   fprintf(stderr, "WriteExecute fwrite() wrote %d bytes, errno=%d, errno2=%d\n",
@@ -348,7 +351,7 @@ void VsamFile::UpdateExecute(UvWorkData *pdata) {
     fprintf(stderr, "%02x ", pdata->recbuf_[i]);
   fprintf(stderr, "\n");
 #endif
-  int nbytes = fupdate(pdata->recbuf_, reclen_, stream_);
+  size_t nbytes = fupdate(pdata->recbuf_, reclen_, stream_);
   int r15 = R15;
 #ifdef DEBUG
   fprintf(stderr, "UpdateExecute fupdate() wrote %d bytes\n", nbytes);
@@ -421,11 +424,11 @@ bool VsamFile::isDatasetExist(const std::string &path, int *perr, int *perr2,
     fclose(stream);
     return true;
   }
-  if (err2 == 0xC00B0641) {
+  if (err2 == static_cast<int>(0xC00B0641)) {
     // 0xC00B0641 is file not found
     return false;
   }
-  if (err2 == 0xC00A0022) {
+  if (err2 == static_cast<int>(0xC00A0022)) {
     // 0xC00A0022 could be if opening an empty dataset as read-only,
     // double-check:
     stream = fopen(dataset.c_str(), "rb+,type=record");
@@ -461,9 +464,6 @@ void VsamFile::open(UvWorkData *pdata) {
   fprintf(stderr, "VsamFile: fopen(%s, %s) returned %p, tid=%d\n",
           dsname.c_str(), omode_.c_str(), stream_, gettid());
 #endif
-  int err = errno;
-  int err2 = __errno2();
-
   if (stream_ == nullptr) {
     createErrorMsg(errmsg_, errno, __errno2(), r15,
                    "open error: fopen() failed");
@@ -485,7 +485,7 @@ void VsamFile::alloc(UvWorkData *pdata) {
     errmsg_ = "Dataset already exists";
     return;
   }
-  if (err2 != 0xC00B0641) {
+  if (err2 != static_cast<int>(0xC00B0641)) {
     // 0xC00B0641 is file not found
     createErrorMsg(errmsg_, err, err2, r15, "alloc error: fopen() failed");
     return;
@@ -552,10 +552,10 @@ int VsamFile::setKeyRecordLengths(const std::string &errPrefix) {
 }
 
 VsamFile::VsamFile(const std::string &path,
-                   const std::vector<LayoutItem> &layout, int key_i, int keypos,
-                   const std::string &omode)
-    : path_(path), layout_(layout), key_i_(key_i), keypos_(keypos),
-      omode_(omode), stream_(nullptr), keylen_(0), rc_(1) {
+                   const std::vector<LayoutItem> &layout, int key_i,
+                   size_t keypos, const std::string &omode)
+    : stream_(nullptr),  path_(path), omode_(omode), layout_(layout), rc_(1),
+      key_i_(key_i), keypos_(keypos), keylen_(0) {
 #ifdef DEBUG
   fprintf(stderr, "In VsamFile constructor for %s.\n", path_.c_str());
 #endif
@@ -599,42 +599,42 @@ void VsamFile::Close(UvWorkData *pdata) {
   pdata->rc_ = 0;
 }
 
-int VsamFile::hexstrToBuffer(char *hexbuf, int buflen, const char *hexstr) {
+size_t VsamFile::hexstrToBuffer(char *hexbuf, size_t buflen, const char *hexstr) {
   DCHECK(hexstr != nullptr && hexbuf != nullptr && buflen > 0);
   memset(hexbuf, 0, buflen);
   if (hexstr[0] == 0)
     return 0;
 
   char xx[2];
-  int i, j, x;
+  size_t i, j, x;
   if (hexstr[0] == '0' && (hexstr[1] == 'x' || hexstr[1] == 'X'))
     hexstr += 2;
   else if (hexstr[0] == 'x' || hexstr[0] == 'X')
     hexstr += 1;
 
-  int hexstrlen = strlen(hexstr);
+  size_t hexstrlen = strlen(hexstr);
   DCHECK(hexstrlen <= (buflen * 2));
   for (i = 0, j = 0; j < buflen && i < hexstrlen - (hexstrlen % 2); ++j) {
     xx[0] = hexstr[i++];
     xx[1] = hexstr[i++];
-    sscanf(xx, "%2x", &x);
+    sscanf(xx, "%2zx", &x);
     hexbuf[j] = x;
   }
   if (j < buflen && hexstrlen % 2) {
     DCHECK(i < strlen(hexstr));
     xx[0] = hexstr[i];
     xx[1] = '0';
-    sscanf(xx, "%2x", &x);
+    sscanf(xx, "%2zx", &x);
     hexbuf[j++] = x;
   }
   DCHECK(j <= buflen);
   return j;
 }
 
-int VsamFile::bufferToHexstr(char *hexstr, int hexstrlen, const char *hexbuf,
-                             int hexbuflen) {
+size_t VsamFile::bufferToHexstr(char *hexstr, size_t hexstrlen,
+                                const char *hexbuf, size_t hexbuflen) {
   DCHECK(hexstr != nullptr && hexbuf != nullptr && hexbuflen > 0);
-  int i, j;
+  size_t i, j;
   for (i = 0, j = 0; i < hexbuflen; i++, j += 2)
     sprintf(hexstr + j, "%02x", hexbuf[i]);
 
@@ -649,8 +649,8 @@ int VsamFile::bufferToHexstr(char *hexstr, int hexstrlen, const char *hexbuf,
 
 bool VsamFile::isStrValid(const LayoutItem &item, const std::string &str,
                           const std::string &errPrefix, std::string &errmsg) {
-  int len = str.length();
-  if (len < item.minLength || len < 0) {
+  size_t len = str.length();
+  if (len < item.minLength) {
     errmsg = errPrefix + " error: length of '" + item.name + "' must be " +
              std::to_string(item.minLength) + " or more.";
     return false;
@@ -665,10 +665,10 @@ bool VsamFile::isStrValid(const LayoutItem &item, const std::string &str,
   return true;
 }
 
-bool VsamFile::isHexBufValid(const LayoutItem &item, const char *buf, int len,
-                             const std::string &errPrefix,
+bool VsamFile::isHexBufValid(const LayoutItem &item, const char *buf,
+                             size_t len, const std::string &errPrefix,
                              std::string &errmsg) {
-  if (len < item.minLength || len < 0) {
+  if (len < item.minLength) {
     errmsg = errPrefix + " error: length of '" + item.name + "' must be " +
              std::to_string(item.minLength) + " or more.";
     return false;
@@ -686,8 +686,8 @@ bool VsamFile::isHexBufValid(const LayoutItem &item, const char *buf, int len,
 bool VsamFile::isHexStrValid(const LayoutItem &item, const std::string &hexstr,
                              const std::string &errPrefix,
                              std::string &errmsg) {
-  int len = hexstr.length();
-  if (len < item.minLength || len < 0) {
+  size_t len = hexstr.length();
+  if (len < item.minLength) {
     errmsg = errPrefix + " error: length of '" + item.name + "' must be " +
              std::to_string(item.minLength) + " or more.";
     return false;
@@ -707,7 +707,7 @@ bool VsamFile::isHexStrValid(const LayoutItem &item, const std::string &hexstr,
     return false;
   }
   len -= start;
-  int digits = (len + (len % 2)) / 2;
+  size_t digits = (len + (len % 2)) / 2;
   if (digits > item.maxLength) {
     errmsg = errPrefix + " error: number of hex digits " +
              std::to_string(digits) + " for '" + item.name +

--- a/VsamFile.h
+++ b/VsamFile.h
@@ -31,23 +31,23 @@ struct LayoutItem {
   enum DataType { STRING, HEXADECIMAL };
 
   std::string name;
-  int minLength;
-  int maxLength;
+  size_t minLength;
+  size_t maxLength;
   DataType type;
-  LayoutItem(std::string &n, int mn, int mx, DataType t)
+  LayoutItem(std::string &n, size_t mn, size_t mx, DataType t)
       : name(n), minLength(mn), maxLength(mx), type(t) {}
 };
 
 struct FieldToUpdate {
-  int offset;
-  int len;
+  size_t offset;
+  size_t len;
 #ifdef DEBUG
   std::string name;
   LayoutItem::DataType type;
-  FieldToUpdate(int ofs, int len, const std::string &nm, LayoutItem::DataType t)
+  FieldToUpdate(size_t ofs, size_t len, const std::string &nm, LayoutItem::DataType t)
       : offset(ofs), len(len), name(nm), type(t) {}
 #else
-  FieldToUpdate(int ofs, int len) : offset(ofs), len(len) {}
+  FieldToUpdate(size_t ofs, size_t len) : offset(ofs), len(len) {}
 #endif
 };
 
@@ -57,12 +57,12 @@ class VsamFile;
 struct UvWorkData {
   UvWorkData(VsamFile *pVsamFile, Napi::Function cbfunc, Napi::Env env,
              const std::string &path = "", char *recbuf = nullptr,
-             char *keybuf = nullptr, int keybuf_len = 0, int equality = 0,
+             char *keybuf = nullptr, size_t keybuf_len = 0, int equality = 0,
              std::vector<FieldToUpdate> *pFieldsToUpdate = nullptr)
       : pVsamFile_(pVsamFile), cb_(Napi::Persistent(cbfunc)), env_(env),
         path_(path), recbuf_(recbuf), keybuf_(keybuf), keybuf_len_(keybuf_len),
-        equality_(equality), pFieldsToUpdate_(pFieldsToUpdate), count_(0),
-        rc_(1) {}
+        equality_(equality), pFieldsToUpdate_(pFieldsToUpdate), rc_(1),
+        count_(1) {}
 
   ~UvWorkData() {
     if (recbuf_) {
@@ -85,11 +85,11 @@ struct UvWorkData {
   std::string path_;
   char *recbuf_;
   char *keybuf_;
-  int keybuf_len_;
+  size_t keybuf_len_;
   int equality_;
   std::vector<FieldToUpdate> *pFieldsToUpdate_;
   int rc_;
-  int count_; // of records updated or deleted to report back
+  size_t count_; // of records updated or deleted to report back
   std::string errmsg_;
 };
 
@@ -117,11 +117,11 @@ typedef struct {
 class VsamFile {
 public:
   VsamFile(const std::string &path, const std::vector<LayoutItem> &layout,
-           int key_i, int keypos, const std::string &omode);
+           int key_i, size_t keypos, const std::string &omode);
   ~VsamFile();
 
   int getKeyNum() const { return key_i_; }
-  int getRecordLength() const { return reclen_; }
+  size_t getRecordLength() const { return reclen_; }
   int getLastError(std::string &errmsg) const {
     errmsg = errmsg_;
     return rc_;
@@ -140,13 +140,13 @@ public:
                              int *perr2 = 0, int *pr15 = 0);
   static bool isStrValid(const LayoutItem &item, const std::string &str,
                          const std::string &errPrefix, std::string &errmsg);
-  static bool isHexBufValid(const LayoutItem &item, const char *buf, int len,
+  static bool isHexBufValid(const LayoutItem &item, const char *buf, size_t len,
                             const std::string &errPrefix, std::string &errmsg);
   static bool isHexStrValid(const LayoutItem &item, const std::string &hexstr,
                             const std::string &errPrefix, std::string &errmsg);
-  static int hexstrToBuffer(char *hexbuf, int buflen, const char *hexstr);
-  static int bufferToHexstr(char *hexstr, int hexstrlen, const char *hexbuf,
-                            int hexbuflen);
+  static size_t hexstrToBuffer(char *hexbuf, size_t buflen, const char *hexstr);
+  static size_t bufferToHexstr(char *hexstr, size_t hexstrlen, const char *hexbuf,
+                            size_t hexbuflen);
 
   /* static because WrappedVsam::Close() delete its VsamFile object */
   static void DeallocExecute(UvWorkData *pdata);
@@ -188,8 +188,8 @@ private:
   int rc_;
   std::string errmsg_;
   int key_i_;
-  int keypos_;
-  unsigned keylen_, reclen_;
+  size_t keypos_;
+  size_t keylen_, reclen_;
 #ifdef DEBUG_CRUD
   // to read the record before delete((err)) for display
   fpos_t freadpos_; // =fgetpos() before fread()

--- a/VsamThread.cpp
+++ b/VsamThread.cpp
@@ -6,6 +6,8 @@
  */
 #include "VsamThread.h"
 
+#include <assert.h>
+
 #ifdef DEBUG
 static const char *getMessageStr(VSAM_THREAD_MSGID msgid) {
   switch (msgid) {

--- a/WrappedVsam.cpp
+++ b/WrappedVsam.cpp
@@ -6,8 +6,10 @@
  */
 #include "WrappedVsam.h"
 #include "VsamThread.h"
+#include <stdio.h>
 #include <sstream>
 #include <unistd.h>
+#include <assert.h>
 
 Napi::FunctionReference WrappedVsam::constructor_;
 
@@ -24,7 +26,7 @@ static void throwError(const Napi::CallbackInfo &info, int errArgNum,
 #endif
   Napi::Env env = info.Env();
   if (errArgNum >= 0 && firstArgType != ARG0_TYPE_NONE) {
-    for (int i = 0; i < info.Length(); i++) {
+    for (size_t i = 0; i < info.Length(); i++) {
       if (!info[i].IsFunction())
         continue;
       Napi::Function cb = info[i].As<Napi::Function>();
@@ -345,7 +347,7 @@ Napi::Object WrappedVsam::Construct(const Napi::CallbackInfo &info,
   int key_i = 0; // for its data type - default to first field if no "key" found
   int curpos = 0, keypos = 0;
 
-  for (int i = 0; i < properties.Length(); ++i) {
+  for (size_t i = 0; i < properties.Length(); ++i) {
     std::string name(static_cast<std::string>(
         Napi::String(env, properties.Get(i).ToString())));
 
@@ -912,7 +914,6 @@ Napi::Value WrappedVsam::FindSync_(const Napi::CallbackInfo &info,
 Napi::Value WrappedVsam::FindEqSync(const Napi::CallbackInfo &info) {
   Napi::HandleScope scope(info.Env());
   UvWorkData *pdata = nullptr;
-  int rc;
   if ((info.Length() == 2 && info[0].IsObject() && info[1].IsNumber()) ||
       (info.Length() == 1 && info[0].IsString())) {
     if (Find(info, __KEY_EQ, "findSync", -1, &pdata, ARG0_TYPE_NONE))
@@ -1018,7 +1019,7 @@ int WrappedVsam::Find(const Napi::CallbackInfo &info, int equality,
   Napi::HandleScope scope(info.Env());
   std::string key;
   char *keybuf = nullptr;
-  int keybuf_len = 0;
+  size_t keybuf_len = 0;
   int key_i = pVsamFile_->getKeyNum();
   std::vector<LayoutItem> &layout = pVsamFile_->getLayout();
   std::string errmsg;

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,10 +2,6 @@
   "targets": [
     {
       "target_name": "vsam.js",
-      "cflags!": [ "-fno-exceptions" ],
-      "cflags_cc!": [ "-fno-exceptions" ],
-      "cflags": [ "-qascii" ],
-      "cflags_cc": [ "-qascii" ],
       "sources": [ "vsam.cpp", "WrappedVsam.cpp", "VsamFile.cpp", "VsamThread.cpp" ],
       "include_dirs": [
          "<!@(node -p \"require('node-addon-api').include\")"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsam.js",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Interact with VSAM Data Sets on z/OS",
   "main": "index.js",
   "repository": "ibmruntimes/vsam.js",


### PR DESCRIPTION
- remove -qascii (invalid for clang); for njsc and xlclang, it's
  already included in common.gypi in Node.js v12, v14 and v16
- include headers as implicit declarations are not allowed
- resolve warnings (sign compares, type-mismatch, unused variables,
  order of ctor init vs declaration)
- bump version to 3.1.0 (from 3.0.1)

I confirmed there's no error or warning from ibm-clang build with Node.js v18.4.0, and njsc build with Node.js v14 and v16; and all 89 tests pass.

clang: https://www-40.ibm.com/servers/resourcelink/svc00100.nsf/pages/openXlCC++11ForZOs24AndZOs25?OpenDocument