### PR TITLE
bump to version 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsam.js",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Interact with VSAM Data Sets on z/OS",
   "main": "index.js",
   "repository": "ibmruntimes/vsam.js",


### PR DESCRIPTION
I had to unpublish Version 3.1.0 as I had log files in the directory I published from, so they got included in the published tar, and the same version can't be re-published.