### PR TITLE
fix memory leaks when errors occur

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsam.js",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Interact with VSAM Data Sets on z/OS",
   "main": "index.js",
   "repository": "ibmruntimes/vsam.js",


### PR DESCRIPTION
When an error (e.g. "unexpected data type") is detected, `uv_queue_work()` doesn't get called (as intended) and therefore memory in recbuf and pFieldsToUpdate_ don't get freed (by the UvWorkData destructor) as no callback function (that destroys the UvWorkData object), gets called - causing memory leak.