### PR TITLE
update Node.js version prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ This Node.js module enables an application to read and modify VSAM datasets on z
 This [Node.js](https://nodejs.org/en/) module is available through the [npm registry](https://www.npmjs.com/).
 -->
 
-Before installing, [download and install IBM SDK for Node.js - z/OS](https://www.ibm.com/products/sdk-nodejs-compiler-zos).
-
-Node.js 8.16.2 or higher is required.
+Before installing, [download and install IBM Open Enterprise SDK for Node.js](https://www.ibm.com/docs/en/sdk-nodejs-zos)
+16 or higher. vsam.js v3.1.0 or higher is required for Node.js 18 or higher.
 
 ## Simple to use
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsam.js",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Interact with VSAM Data Sets on z/OS",
   "main": "index.js",
   "repository": "ibmruntimes/vsam.js",


### PR DESCRIPTION
commit a72cea7a upgraded vsam.js to v3.1.0 and enabled vsam.js to build with clang.

Also update the no-longer-valid link to the Node.js versions.